### PR TITLE
Enable Webpack hot module replacement for Redux reducers

### DIFF
--- a/generators/build-tool/generateWebpackBuildTool.js
+++ b/generators/build-tool/generateWebpackBuildTool.js
@@ -49,6 +49,7 @@ export default async function genereateWebpackBuildTool(params) {
   switch (params.jsFramework) {
     case 'react':
       await replaceCodeMemory(params, 'webpack.config.js', 'WEBPACK_JAVASCRIPT_LOADER', await getModule('build-tool/webpack/webpack-react-loader.js'));
+      await replaceCodeMemory(params, 'app/store/configureStore.js', 'WEBPACK_HOT_REDUCER', await getModule('build-tool/webpack/webpack-hot-reducer.js'));
       await addNpmPackageMemory('babel-plugin-react-transform', params, true);
       await addNpmPackageMemory('react-transform-hmr', params, true);
       await addNpmPackageMemory('react-transform-catch-errors', params, true);

--- a/generators/build-tool/modules/webpack/webpack-hot-reducer.js
+++ b/generators/build-tool/modules/webpack/webpack-hot-reducer.js
@@ -1,0 +1,8 @@
+ 
+if (module.hot) {
+  // Enable hot module replacement for reducers
+  module.hot.accept('../reducers', () => {
+    const nextRootReducer = require('../reducers');
+    store.replaceReducer(nextRootReducer);
+  });
+}

--- a/generators/js-framework/modules/react/store/configureStore.js
+++ b/generators/js-framework/modules/react/store/configureStore.js
@@ -8,6 +8,7 @@ export default function configureStore(initialState) {
     initialState,
     //= REDUX_STORE_ENHANCER_INDENT2
   );
+  //= WEBPACK_HOT_REDUCER_INDENT1
 
   return store;
 }


### PR DESCRIPTION
Should resolve #86

I only added the snippet to webpack, however if you should add support for [react-native](https://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) or [browserify-hmr](https://github.com/AgentME/browserify-hmr) in the future, they should use the same module.hot api.