### PR TITLE
React test runner conflict and compiler addition.

### DIFF
--- a/generators/testing/generateTestingMocha.js
+++ b/generators/testing/generateTestingMocha.js
@@ -14,6 +14,10 @@ export default async function generateTestingMocha(params) {
         // Server-side tests
         set(params, ['build', 'test', 'server', 'app.test.js'], await getModule('testing/mocha/app.test-json.js'));
 
+        // Default NPM scripts for both server and client tests
+        await addNpmScriptMemory('test', 'npm run test:server && npm run test:client', params);
+        await addNpmScriptMemory('test:server', 'mocha --recursive', params);
+
         // Client-side tests
         switch (params.jsFramework) {
           case 'react':
@@ -31,9 +35,10 @@ export default async function generateTestingMocha(params) {
             addNpmPackageMemory('enzyme', params, true);
             addNpmPackageMemory('react-addons-test-utils', params, true);
 
+            console.log('about to set test runner');
             await addNpmScriptMemory('test', 'npm run test:client && npm run test:server', params);
             await addNpmScriptMemory('test:client', 'mocha test/client --recursive --compilers js:babel-register', params);
-            await addNpmScriptMemory('test:server', 'mocha test/server --recursive', params);
+            await addNpmScriptMemory('test:server', 'mocha test/server --recursive --compilers js:babel-register', params);
             break;
           case 'angularjs':
             if (params.buildTool === 'gulp') {
@@ -60,9 +65,6 @@ export default async function generateTestingMocha(params) {
           default:
             break;
         }
-        // NPM scripts for both server and client tests
-        await addNpmScriptMemory('test', 'npm run test:server && npm run test:client', params);
-        await addNpmScriptMemory('test:server', 'mocha --recursive', params);
       } else {
         // Server-side tests
         set(params, ['build', 'test', 'app.test.js'], await getModule('testing/mocha/app.test.js'));

--- a/generators/testing/generateTestingMocha.js
+++ b/generators/testing/generateTestingMocha.js
@@ -35,7 +35,6 @@ export default async function generateTestingMocha(params) {
             addNpmPackageMemory('enzyme', params, true);
             addNpmPackageMemory('react-addons-test-utils', params, true);
 
-            console.log('about to set test runner');
             await addNpmScriptMemory('test', 'npm run test:client && npm run test:server', params);
             await addNpmScriptMemory('test:client', 'mocha test/client --recursive --compilers js:babel-register', params);
             await addNpmScriptMemory('test:server', 'mocha test/server --recursive --compilers js:babel-register', params);


### PR DESCRIPTION
React mocha tests now require babel compiler. Added support for this to the react test runner.

Default test runners were overriding the framework-specific ones. Moved defaults to head of file, allowing subsequent framework runners to override.