### PR TITLE
CSS fix for issue #115, Foundation menu layout

### DIFF
--- a/generators/css-framework/modules/foundation/main.css
+++ b/generators/css-framework/modules/foundation/main.css
@@ -133,7 +133,7 @@ footer {
 }
 
 .top-bar-title {
-  margin: 1rem 1rem 0;
+  margin: 1rem 1rem 1rem;
 }
 
 .top-bar-title > a {

--- a/generators/css-framework/modules/foundation/main.scss
+++ b/generators/css-framework/modules/foundation/main.scss
@@ -167,7 +167,7 @@ footer {
 }
 
 .top-bar-title {
-  margin: 1rem 1rem 0;
+  margin: 1rem 1rem 1rem;
   > a {
     margin-left: 10px;
   }

--- a/generators/template-engine/modules/handlebars/views/partials/header-auth-foundation.handlebars
+++ b/generators/template-engine/modules/handlebars/views/partials/header-auth-foundation.handlebars
@@ -1,5 +1,5 @@
 <div class="top-bar-right">
-  <ul class="menu">
+  <ul class="vertical medium-horizontal menu">
   {{#if user}}
     <li>
       {{#if user.picture}}

--- a/generators/template-engine/modules/handlebars/views/partials/header-foundation.handlebars
+++ b/generators/template-engine/modules/handlebars/views/partials/header-foundation.handlebars
@@ -7,7 +7,7 @@
   </div>
   <div id="responsive-menu">
     <div class="top-bar-left">
-      <ul class="menu">
+      <ul class="vertical medium-horizontal menu">
         <li><a href="/" class="{{#ifeq title 'Home'}}active{{/ifeq}}">Home</a></li>
         <li><a href="/contact" class="{{#ifeq title 'Contact'}}active{{/ifeq}}">Contact</a></li>
       </ul>

--- a/generators/template-engine/modules/jade/views/header-auth-foundation.jade
+++ b/generators/template-engine/modules/jade/views/header-auth-foundation.jade
@@ -1,5 +1,5 @@
 .top-bar-right
-  ul.dropdown.menu(data-dropdown-menu)
+  ul.vertical.medium-horizontal.menu
     if user
       li
         if user.picture

--- a/generators/template-engine/modules/jade/views/header-foundation.jade
+++ b/generators/template-engine/modules/jade/views/header-foundation.jade
@@ -5,7 +5,7 @@
     a(href='/') Project name
   #responsive-menu
     .top-bar-left
-      ul.menu
+      ul.vertical.medium-horizontal.menu
         li(class=(title == 'Home') ? 'active' : null)
           a(href='/') Home
         li(class=(title == 'Contact') ? 'active' : null)

--- a/generators/template-engine/modules/nunjucks/views/partials/header-auth-foundation.html
+++ b/generators/template-engine/modules/nunjucks/views/partials/header-auth-foundation.html
@@ -1,5 +1,5 @@
 <div class="top-bar-right">
-  <ul class="menu">
+  <ul class="vertical medium-horizontal menu">
     {% if user %}
     <li>
       {% if user.picture %}

--- a/generators/template-engine/modules/nunjucks/views/partials/header-foundation.html
+++ b/generators/template-engine/modules/nunjucks/views/partials/header-foundation.html
@@ -7,7 +7,7 @@
   </div>
   <div id="responsive-menu">
     <div class="top-bar-left">
-      <ul class="menu">
+      <ul class="vertical medium-horizontal menu">
         <li><a href="/" class="{% if title == 'Home' %}active{% endif %}">Home</a></li>
         <li><a href="/contact" class="{% if title == 'Contact' %}active{% endif %}">Contact</a></li>
       </ul>


### PR DESCRIPTION
This fixes the layout issue for the Foundation responsive menu. It correctly stacks the menu links vertically on mobile and horizontally on larger sizes. It also adds a missing bottom margin to the mobile top-bar-title.

This isn't a complete fix for #115, this solves the CSS part to it. **To enable menu toggle and hide functionality** (to completely fix this issue), **some extra work is required**. As described in the comments of the issue, the responsive menu requires JavaScript and it needs to be initialized for each JS framework. 

Referenced on the [Foundation docs](http://foundation.zurb.com/sites/docs/javascript.html#initializing), use `$(document).foundation();` to initialize all Foundation JavaScript. You could initialize just the menu component, but this might be confusing for users who try to implement other JavaScript components. They would have to add each initialization for any plugin they use when they would expect it to work without doing this.

This is what the pull request changes:

Before
![before 115 fix](https://cloud.githubusercontent.com/assets/8602276/16064914/b6fbad2c-32f9-11e6-9305-8de10365d03a.jpg)

After
![after 115 fix](https://cloud.githubusercontent.com/assets/8602276/16064915/bb15bf7e-32f9-11e6-98d0-a1b0cc746004.jpg)