### PR TITLE
Exclude bundle.*.js and stats.json with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ bower_components
 Thumbs.db
 
 .env
+
+# Bundled scripts
+website/assets/js/bundle.*.js
+
+# Stats
+stats.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,4 @@ Thumbs.db
 .env
 
 # Bundled scripts
-website/assets/js/bundle.*.js
-
-# Stats
-stats.json
+website/assets/js/bundle*.js


### PR DESCRIPTION
Added compiled bundle.*.js and local stats.json files to .gignore to ensure they are not accidentally committed, if present.