### PR TITLE
Fix Foundation sticky footer

### DIFF
--- a/generators/css-framework/modules/foundation/main.css
+++ b/generators/css-framework/modules/foundation/main.css
@@ -4,6 +4,7 @@
 html {
   position: relative;
   min-height: 100%;
+  height: auto;
 }
 
 body {

--- a/generators/css-framework/modules/foundation/main.scss
+++ b/generators/css-framework/modules/foundation/main.scss
@@ -49,6 +49,7 @@
 html {
   position: relative;
   min-height: 100%;
+  height: auto;
 }
 
 body {


### PR DESCRIPTION
This fixes #116.

The problem was Foundation adds `height: 100%` to the html and body tags. So I've added a rule in the main CSS files to override it. Setting height to auto overrides Foundation's rule without setting a static value - removing it.

I'm not sure why Foundation does this. Bootstrap doesn't, which is why it works even with the same footer CSS. 

This might cause issues later if a user adds a Foundation component because <html> might need a height of 100%, I'm not sure. But it works and doesn't break anything. I've tested it with all 3 template engines with CSS and SASS.