### PR TITLE
Change website so that templating is not required for angular

### DIFF
--- a/website/Home.js
+++ b/website/Home.js
@@ -91,7 +91,7 @@ class Home extends React.Component {
         generateDownloadLinkInProgress: false
       });
 
-    } else if (state.platform === 'node' && !state.templateEngine) {
+    } else if (state.platform === 'node' && state.jsFramework !== 'angularjs' && !state.templateEngine) {
       console.info('Please select a template engine.');
       return this.setState({
         templateEngineValidationError: 'Please select a template engine.',


### PR DESCRIPTION
Noticed this when trying out the site, and spotted that there's an error in the console when trying to generate an angular project - `Please select a template engine.`, which isn't shown to the user as the template engine section where the error is displayed isn't visible when angular is selected. 

At the moment this means you can't generate an angular project with any configuration as it expects a template engine to be set.

This changes the download check to not expect a template engine if `angularjs` is set as the `jsFramework`.

The project still generates fine, and installs/runs okay too.