### PR TITLE
postinstall script error in package.json for the Electron generator.

### DIFF
--- a/generators/electron/modules/package.json
+++ b/generators/electron/modules/package.json
@@ -87,7 +87,12 @@
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0"
   },
+  "devEngines": {
+    "node": ">=6.x",
+    "npm": ">=3.8"
+  },
   "engines": {
-    "node": "Electron app description"
+    "node": ">=6.x",
+    "npm": ">=3.8"
   }
 }


### PR DESCRIPTION
Just a minor change for the package.json file in the Electron generator. This corrects a type error in the postinstall script since `check-dev-engines.js` expects a `devEngines` entry [mentioned here](https://github.com/npm/npm/issues/9765). 

![postinstall-error](https://cloud.githubusercontent.com/assets/2832117/16710783/518d337a-45f0-11e6-863e-d1f5749cb537.png)
