### PR TITLE
Fix angular template watched path

### DIFF
--- a/generators/build-tool/modules/gulp/angularjs/angularjs-watch.js
+++ b/generators/build-tool/modules/gulp/angularjs/angularjs-watch.js
@@ -1,2 +1,2 @@
-gulp.watch('app/views/**/*.html', ['templates']);
+gulp.watch('app/partials/**/*.html', ['templates']);
 gulp.watch('app/**/*.js', ['angular']);


### PR DESCRIPTION
By default the templates path is `app/partials`.
This way the `templates` task works fine on watch task.