### PR TITLE
Font path issue fixed for sass boostrap package

### DIFF
--- a/generators/css-framework/generateCssFrameworkBootstrap.js
+++ b/generators/css-framework/generateCssFrameworkBootstrap.js
@@ -180,12 +180,23 @@ export default async function generateCssFrameworkBootstrap(params) {
     set(params.build, ['public', 'js', 'lib', 'bootstrap.js'], await getModule('css-framework/bootstrap/js/bootstrap.js'));
     set(params.build, ['public', 'js', 'lib', 'jquery.js'], await getModule('css-framework/jquery/jquery.js'));
   }
+  
+  if (params.cssPreprocessor == 'sass') {
+	set(params.build, ['public', 'fonts', 'bootstrap', 'glyphicons-halflings-regular.eot'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.eot'));
+	set(params.build, ['public', 'fonts', 'bootstrap', 'glyphicons-halflings-regular.svg'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.svg'));
+	set(params.build, ['public', 'fonts', 'bootstrap', 'glyphicons-halflings-regular.ttf'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.ttf'));
+	set(params.build, ['public', 'fonts', 'bootstrap', 'glyphicons-halflings-regular.woff'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff'));
+	set(params.build, ['public', 'fonts', 'bootstrap', 'glyphicons-halflings-regular.woff2'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff2'));  
+  }
+  else{
+	set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.eot'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.eot'));
+	set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.svg'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.svg'));
+	set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.ttf'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.ttf'));
+	set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.woff'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff'));
+	set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.woff2'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff2'));  
+  }
 
-  set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.eot'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.eot'));
-  set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.svg'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.svg'));
-  set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.ttf'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.ttf'));
-  set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.woff'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff'));
-  set(params.build, ['public', 'fonts', 'glyphicons-halflings-regular.woff2'], await getModule('css-framework/bootstrap/fonts//glyphicons-halflings-regular.woff2'));
+  
 
   const htmlJsImport = params.cssPreprocessorOptions.includes('minifiedCss') ?
     await getModule('css-framework/bootstrap/html-js-min-import.html') :


### PR DESCRIPTION
- In boostrap default/less distribution package, fonts are stored on path './font/' but in sass package path is './font/bootstrap/'

so to fix that issue the generateCssFrameworkBootstrap.js file is updated to generate different path for fonts file in case of sass processor.

or you can follow the other solution 2

```
update line no 83 in "megaboilerplate\generators\css-framework\modules\bootstrap\sass\bootstrap\_variables.scss"

$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/") !default;

with

$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/") !default;
```