### PR TITLE
Reordered express middleware to resolve server side render issue when…

### DIFF
--- a/generators/framework/modules/express/server.js
+++ b/generators/framework/modules/express/server.js
@@ -46,9 +46,9 @@ app.use(expressValidator());
 //= SESSION_MIDDLEWARE
 //= PASSPORT_MIDDLEWARE
 //= USER_HELPER_MIDDLEWARE
-app.use(express.static(path.join(__dirname, 'public')));
 //= IS_AUTHENTICATED_MIDDLEWARE
 //= WEBPACK_MIDDLEWARE
+app.use(express.static(path.join(__dirname, 'public')));
 
 //= HOME_ROUTE
 //= CONTACT_ROUTE


### PR DESCRIPTION
… using webpack + react + express

Original version had an issue with the following steps:
1) Run `npm start` at least once.
2) Make some changes in any React component files.
3) Run `npm start` again.
4) Open it in browser.
5) You'll see it loads changed code initially but refreshes back to code generated in Step 1

This issue was resolved by reordering express middleware so that static middleware is located below Webpack middlewares.