### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.3.0",
     "shortid": "^2.2.6",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.9",
     "traverse": "^0.6.6",
     "velocity": "^0.7.2",
     "velocity-react": "^1.1.5",

--- a/website/Home.js
+++ b/website/Home.js
@@ -1,5 +1,6 @@
 import haikunate from 'haikunator';
 import React from 'react';
+import swal from 'sweetalert2';
 import Header from './Header';
 import Footer from './Footer';
 import Platform from './sections/Platform';
@@ -29,9 +30,6 @@ class Home extends React.Component {
   }
 
   componentDidMount() {
-    // require it here to avoid "window is not defined" error during server-side rendering
-    const swal = require('sweetalert');
-
     try {
       const disableAutoScroll = localStorage.getItem('disableAutoScroll');
       this.setState({
@@ -182,9 +180,8 @@ class Home extends React.Component {
         const body = encodeURIComponent('\n##### :boom: Error Stack Trace\n' + '\`\`\`js\n' + jqXHR.responseJSON.stack + '\n\`\`\`');
         swal({
           title: 'Server Error',
-          text: `${jqXHR.responseJSON.message}<br><strong><a href='https://github.com/sahat/megaboilerplate/issues/new?title=${title}&body=${body}' target="_blank">Report a bug</a></strong>`,
-          type: 'error',
-          html: true
+          html: `${jqXHR.responseJSON.message}<br><strong><a href='https://github.com/sahat/megaboilerplate/issues/new?title=${title}&body=${body}' target="_blank">Report a bug</a></strong>`,
+          type: 'error'
         });
       });
     } else {
@@ -212,9 +209,8 @@ class Home extends React.Component {
         const body = encodeURIComponent('\n##### :boom: Error Stack Trace\n' + '\`\`\`js\n' + jqXHR.responseJSON.stack + '\n\`\`\`');
         swal({
           title: 'Server Error',
-          text: `${jqXHR.responseJSON.message}<br><strong><a href='https://github.com/sahat/megaboilerplate/issues/new?title=${title}&body=${body}' target="_blank">Report a bug</a></strong>`,
-          type: 'error',
-          html: true
+          html: `${jqXHR.responseJSON.message}<br><strong><a href='https://github.com/sahat/megaboilerplate/issues/new?title=${title}&body=${body}' target="_blank">Report a bug</a></strong>`,
+          type: 'error'
         });
         this.setState({ isDownloadLoading: false });
       });

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -1,7 +1,6 @@
 @import "bootstrap.min.css";
 @import "hint.css";
 @import "animate.css";
-@import "sweetalert.css";
 
 body {
   /*background-color: #f4f5f7;*/


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. No need in the workaround because of the "window is not defined" exception

5. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  