### PR TITLE
Maintains consistency between react and react-dom packages versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postcss-middleware": "^1.1.2",
     "raw-loader": "^0.5.1",
     "react": "^15.3",
-    "react-dom": "15.3",
+    "react-dom": "^15.3",
     "react-router": "^2.8.1",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",


### PR DESCRIPTION
The installation gave me problems at 2019-09-05, node version 8.11.4 (LTS) and npm versions 5.6.0 and 5.7.1 in building phase.

The issue is the inconsistency of `react` and `react-dom` versions.